### PR TITLE
Adds labeling for modules

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -76,3 +76,11 @@ example:
           - city_example.py
           - kingdom_example.py
           - scenario_example.py
+campaign:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .cspell/campaigns.txt
+troops:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .cspell/troops.txt


### PR DESCRIPTION
This PR adds new labels for the different modules and their related files (data files, tests, dictionaries, etc). From now on, each time a new modules is created, it should come with its own label.

I have backfilled the classification of issues and PRs to follow the new labeling.