### PR TITLE
Corrects scenario example

### DIFF
--- a/scenario_example.py
+++ b/scenario_example.py
@@ -66,6 +66,16 @@ scenario: Scenario = Scenario.from_list(
             "name": "Hernici",
             "buildings": {
                 "town_hall": 1,
+                "outcrop_mine": 1,
+                "fishing_village": 1,
+                "hunters_lodge": 4,
+            },
+        },
+        {
+            "campaign": "Unification of Italy",
+            "name": "Hernici",
+            "buildings": {
+                "town_hall": 1,
                 "temple": 1,
                 "outcrop_mine": 1,
                 "fishing_village": 1,
@@ -80,6 +90,62 @@ scenario: Scenario = Scenario.from_list(
                 "outcrop_mine": 1,
                 "fishing_village": 1,
                 "large_mine": 4,
+            },
+        },
+    ],
+    configuration = {
+        "storage": {
+            "include": False,
+        },
+        "defenses": {
+            "include": False,
+        },
+    },
+)
+
+scenario.display_scenario()
+print()
+
+scenario: Scenario = Scenario.from_list(
+    data = [
+        {
+            "campaign": "Conquest of Britain",
+            "name": "Anderitum",
+            "buildings": {
+                "town_hall": 1,
+                "supply_dump": 1,
+                "temple": 1,
+                "hunters_lodge": 4,
+            },
+        },
+        {
+            "campaign": "Conquest of Britain",
+            "name": "Anderitum",
+            "buildings": {
+                "town_hall": 1,
+                "supply_dump": 1,
+                "hunters_lodge": 5,
+            },
+        },
+        {
+            "campaign": "Conquest of Britain",
+            "name": "Anderitum",
+            "buildings": {
+                "town_hall": 1,
+                "supply_dump": 1,
+                "hunters_lodge": 4,
+                "vineyard": 1,
+            },
+        },
+        {
+            "campaign": "Conquest of Britain",
+            "name": "Anderitum",
+            "buildings": {
+                "town_hall": 1,
+                "temple": 1,
+                "supply_dump": 1,
+                "large_farm": 2,
+                "vineyard": 1,
             },
         },
     ],


### PR DESCRIPTION
This PR corrects some scenarios in the scenario examples script. There's nothing wrong with the `Scenario` class itself. But the improved city validations introduced in #118 flagged some scenarios as not possible, and thus are raising errors.