### PR TITLE
Adds new staffing strategies

### DIFF
--- a/modules/city.py
+++ b/modules/city.py
@@ -165,6 +165,9 @@ class City:
         staffing_strategy (str): The name of the staffing strategy to be used. Defaults to "production_first". Possible
             values are:
             
+            - "zero" will set the assigned workers for all buildings to zero.
+            - "none" will not assign any additional workers to any buildings. This is relevant when creating cities by
+                passing collections of buildings that already assign workers to buildings.
             - "production_first" will first assign workers production-buildings and then effects-buildings.
             - "production_only" will only assign workers to production-buildings.
             - "effects_first" will first assign workers effects-buildings and then production-buildings.
@@ -603,6 +606,8 @@ class City:
     
     def _validate_staffing_strategy(self, staffing_strategy: str) -> None:
         allowed_building_staffing_strategies: list[str] = [
+            "zero",
+            "none",
             "production_first",
             "production_only",
             "effects_first",
@@ -624,6 +629,14 @@ class City:
             self.assigned_workers += 1
     
     def _staff_buildings(self) -> None:
+        if self.staffing_strategy == "none":
+            return
+        
+        if self.staffing_strategy == "zero":
+            for building in self.buildings:
+                building.set_workers(qty = 0)
+            return
+        
         # Production buildings sorted by productivity levels. The prod. level of each building is determined by the
         # total sum of all produced rss. For most buildings, this is equal to the product of the one rss it produces
         # times the number of workers. The only exception is the HL which produces all 3 rss. Worker productivity is

--- a/tests/test_city.py
+++ b/tests/test_city.py
@@ -1527,6 +1527,64 @@ class TestWorkersDistribution:
         assert city.production.maintenance_costs.food == 14
         assert city.production.balance.food == -14
     
+    def test_none_strategy_with_no_pre_assigned_workers(self, _roman_food_producer_buildings: BuildingsCount) -> None:
+        city: City = City.from_buildings_count(
+            campaign = "Unification of Italy",
+            name = "Populonia",
+            buildings = _roman_food_producer_buildings,
+            staffing_strategy = "none",
+        )
+        
+        for building in city.buildings:
+            assert building.workers == 0
+    
+    def test_none_strategy_with_pre_assigned_workers(self) -> None:
+        city: City = City(
+            campaign = "Unification of Italy",
+            name = "Populonia",
+            buildings = [
+                Building(id = "city_hall"),
+                Building(id = "basilica", workers = 0),
+                Building(id = "watch_tower", workers = 1),
+                Building(id = "hospital", workers = 2),
+                Building(id = "training_ground", workers = 1),
+            ],
+            staffing_strategy = "none",
+        )
+        
+        assert city.get_building(id = "basilica").workers == 0
+        assert city.get_building(id = "watch_tower").workers == 1
+        assert city.get_building(id = "hospital").workers == 2
+        assert city.get_building(id = "training_ground").workers == 1
+    
+    def test_zero_strategy_with_no_pre_assigned_workers(self, _roman_food_producer_buildings: BuildingsCount) -> None:
+        city: City = City.from_buildings_count(
+            campaign = "Unification of Italy",
+            name = "Populonia",
+            buildings = _roman_food_producer_buildings,
+            staffing_strategy = "zero",
+        )
+        
+        for building in city.buildings:
+            assert building.workers == 0
+    
+    def test_zero_strategy_with_pre_assigned_workers(self) -> None:
+        city: City = City(
+            campaign = "Unification of Italy",
+            name = "Populonia",
+            buildings = [
+                Building(id = "city_hall"),
+                Building(id = "basilica", workers = 0),
+                Building(id = "watch_tower", workers = 1),
+                Building(id = "hospital", workers = 2),
+                Building(id = "training_ground", workers = 1),
+            ],
+            staffing_strategy = "zero",
+        )
+        
+        for building in city.buildings:
+            assert building.workers == 0
+    
     def test_unknown_staffing_strategy_raises_error(self) -> None:
         with raises(expected_exception = UnknownBuildingStaffingStrategyError):
             city: City = City(


### PR DESCRIPTION
This PR adds two new strategies:

- `none` this strategy will leave worker assignments as they were at creation time.
- `zero` this strategy will set all buildings to zero workers, regardless of the workers that may have been assigned at city creation time.

For cities created via the `City.from_buildings_count()` method, which does not allow already assigning workers to buildings at city creation time, both these strategies have the same implication: all buildings will have zero workers.

For cities created by the standard `City` constructor the story is different. Here users need to pass a collection (list) of `Building` objects and these objects do allow for worker assignments at creation time. Therefore, the `none` strategy means "leave workers as when the city was created", and the `zero` strategy means "set all worker assignments to zero".

This PR adds the necessary unit tests to check this new strategies.