### PR TITLE
Update security of GitHub Actions workflows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -104,7 +104,8 @@ jobs:
       - label-pr
       - lint
       - spell-check
-    permissions: {}
+    permissions:
+      contents: read
     steps:
       - name: Checkout 🛎️
         id: checkout
@@ -128,8 +129,11 @@ jobs:
     name: Run examples
     runs-on: ubuntu-latest
     needs:
-      - unit-tests
-    permissions: {}
+      - label-pr
+      - lint
+      - spell-check
+    permissions:
+      contents: read
     steps:
       - name: Checkout 🛎️
         id: checkout


### PR DESCRIPTION
This PR enhances the security of GHA workflows. Changes include:

- setting the version of the actions to a specific SHA instead of tag to prevent supply-chain attacks.
- setting permissions for all jobs to `read-all` by default. Only the ones that need more permissions are elevated.
- adds an `alls-green` job to ensure that all jobs have passed.