### PR TITLE
Fixes `alls-green` job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -104,7 +104,6 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     needs:
-      - label-pr
       - lint
       - spell-check
     permissions:
@@ -132,7 +131,6 @@ jobs:
     name: Run examples
     runs-on: ubuntu-latest
     needs:
-      - label-pr
       - lint
       - spell-check
     permissions:
@@ -178,4 +176,5 @@ jobs:
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
+          allowed-skips: label-pr
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
This PR fixes the `alls-green` job. Currently it is listing all jobs. But the `label-pr` does not run on pushes (e.g. when a PR is merged). Therefore, the workflow always fails on main, even though all required jobs have indeed passed (or were skipped).