### PR TITLE
Adds CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @daczarne

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -161,7 +161,7 @@ jobs:
           uv run python -m examples.kingdom
 
   alls-green:
-    name: Ensure all checks have passed
+    name: All checks passed
     if: always()
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
This PR adds the CODEOWNERS file. This file is needed to enforce PR review now that the repository is public.

It also simplifies the name of the alls-green job. This is done because this is the status check used for the branch protection rules.